### PR TITLE
Deprecation Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***This package is deprecated in favor of [MarginalTreatmentEffects.jl](https://github.com/a-torgovitsky/MarginalTreatmentEffects.jl).***
+
 # Mogstad, Torgovitsky, and Walters (2021)
 
 Repo: https://github.com/a-torgovitsky/MarginalTreatmentEffectsWithMultipleInstruments.jl

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ MarginalTreatmentEffects.jl replicates the figures in the following papers:
 3. "Policy Evaluation with Multiple Instrumental Variables"
     Mostad, Torgovitsky, and Walters (Forthcoming, _Journal of Econometrics_)
 
-# Mogstad, Torgovitsky, and Walters (2021)
+# Mogstad, Torgovitsky, and Walters (Forthcoming, _Journal of Econometrics_)
 
 Repo: https://github.com/a-torgovitsky/MarginalTreatmentEffectsWithMultipleInstruments.jl
 
-This package contains the code for the figures and simulations in "Policy Evaluation with Multiple Instrumental Variables" by Mogstad, Torgovitsky, and Walters (2021).
+This package contains the code for the figures and simulations in "Policy Evaluation with Multiple Instrumental Variables" by Mogstad, Torgovitsky, and Walters (Forthcoming).
 The code is written in Julia and tested with Julia version 1.6.0.
 To load/install dependencies:
 ```julia

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-***This package is deprecated in favor of [MarginalTreatmentEffects.jl](https://github.com/a-torgovitsky/MarginalTreatmentEffects.jl).***
+***This package is superceded by [MarginalTreatmentEffects.jl](https://github.com/a-torgovitsky/MarginalTreatmentEffects.jl).***
+MarginalTreatmentEffects.jl replicates the figures in the following papers:
+
+1. "Using Instrumental Variables for Inference About Policy Relevant Treatment Parameters"
+    Mogstad, Santos, and Torgovitsky (2018, _Econometrica_)
+2. "Identification and Extrapolation of Causal Effects with Instrumental Variables"
+    Mogstad and Torgovitsky (2018, _Annual Review of Economics_)
+3. "Policy Evaluation with Multiple Instrumental Variables"
+    Mostad, Torgovitsky, and Walters (Forthcoming, _Journal of Econometrics_)
 
 # Mogstad, Torgovitsky, and Walters (2021)
 


### PR DESCRIPTION
As we discussed in a-torgovitsky/MarginalTreatmentEffects.jl#1, our plan is to move all the code over to `MarginalTreatmentEffects.jl` so the replication files for all three papers are in one repo.
This PR adds a quick note at the top of the README that links to `MarginalTreatmentEffects.jl`.

[This link](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories) about archiving repositories may be of interest.